### PR TITLE
Fix build errors in JDK1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,6 @@
    <jersey.version>1.12</jersey.version>
  </properties>
 
-
-  <!-- get every artifact through maven.glassfish.org, which proxies all the artifacts that we need -->
   <repositories>
     <repository>
       <id>m.j.ci-public</id>

--- a/pom.xml
+++ b/pom.xml
@@ -23,15 +23,15 @@
   <!-- get every artifact through maven.glassfish.org, which proxies all the artifacts that we need -->
   <repositories>
     <repository>
-      <id>m.g.o-public</id>
-      <url>https://maven.glassfish.org/content/groups/public/</url>
+      <id>m.j.ci-public</id>
+      <url>http://maven.jenkins-ci.org/content/repositories/releases/</url>
     </repository>
   </repositories>
 
   <pluginRepositories>
     <pluginRepository>
-      <id>m.g.o-public</id>
-      <url>https://maven.glassfish.org/content/groups/public/</url>
+      <id>m.j.ci-public</id>
+      <url>http://maven.jenkins-ci.org/content/repositories/releases/</url>
     </pluginRepository>
   </pluginRepositories>
   <dependencies>
@@ -63,4 +63,13 @@
             <version>${jersey.version}</version>
         </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jvnet.hudson.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <version>3.0.1</version>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
I had issues building the plugin on my OSX using JDK1.7. 
1) Couldn't resolve the jenkins plugin org.jenkins-ci:annotation-indexer:jar:1.4 - resolved by adding jenkins repos
2) this error: https://bugs.eclipse.org/bugs/show_bug.cgi?id=389581 - resolved by using maven-hpi-plugin v3.0.1