### PR TITLE
Use the Jenkins Credentials Plugin to communicate with Chatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 target
 work
 .DS_Store
+.classpath
+.settings/
+.project
+/bin/

--- a/pom.xml
+++ b/pom.xml
@@ -1,75 +1,90 @@
 <project 
-	xmlns="http://maven.apache.org/POM/4.0.0" 
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xmlns="http://maven.apache.org/POM/4.0.0" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.480.3</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>1.580.1</version><!-- which version of Jenkins is this plugin built against? -->
   </parent>
-
+  
   <groupId>com.pocketsoap</groupId>
   <artifactId>ChatterPlugin</artifactId>
-  <version>1.22</version>
+  <version>2.0</version>
   <packaging>hpi</packaging>
   <name>Chatter plugin</name>
   <description>Post your build results to Chatter</description>
   <url>https://github.com/superfell/JenkinsChatterPlugin</url>
-
- <properties>
-   <jersey.version>1.12</jersey.version>
- </properties>
-
- <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->
- <repositories>
-   <repository>
-     <id>repo.jenkins-ci.org</id>
-     <url>http://repo.jenkins-ci.org/public/</url>
-   </repository>
- </repositories>
-
- <pluginRepositories>
-   <pluginRepository>
-     <id>repo.jenkins-ci.org</id>
-     <url>http://repo.jenkins-ci.org/public/</url>
-   </pluginRepository>
- </pluginRepositories>
-
+  
+  <properties>
+    <jersey.version>1.12</jersey.version>
+  </properties>
+  
+  <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>http://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>http://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
+  
   <dependencies>
-  	<dependency>
-  		<groupId>commons-httpclient</groupId>
-  		<artifactId>commons-httpclient</artifactId>
-  		<version>3.1</version>
-  		<type>jar</type>
-  		<scope>compile</scope>
-  	</dependency>
-      <dependency>
-          <groupId>commons-io</groupId>
-          <artifactId>commons-io</artifactId>
-          <version>2.4</version>
-          <type>jar</type>
-          <scope>compile</scope>
-      </dependency>
-      <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-            <version>1.9.2</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-client</artifactId>
-            <version>${jersey.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-core</artifactId>
-            <version>${jersey.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-json</artifactId>
-            <version>${jersey.version}</version>
-        </dependency>
+    <dependency>
+      <groupId>commons-httpclient</groupId>
+      <artifactId>commons-httpclient</artifactId>
+      <version>3.1</version>
+      <type>jar</type>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.4</version>
+      <type>jar</type>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-mapper-asl</artifactId>
+      <version>1.9.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.jersey</groupId>
+      <artifactId>jersey-client</artifactId>
+      <version>${jersey.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.jersey</groupId>
+      <artifactId>jersey-core</artifactId>
+      <version>${jersey.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.jersey</groupId>
+      <artifactId>jersey-json</artifactId>
+      <version>${jersey.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+      <version>1.22</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>junit</artifactId>
+      <version>1.8</version>
+    </dependency>
   </dependencies>
 </project>

--- a/src/main/resources/com/pocketsoap/ChatterNotifier/config.jelly
+++ b/src/main/resources/com/pocketsoap/ChatterNotifier/config.jelly
@@ -9,12 +9,9 @@
     Creates a text field that shows the value of the "name" property.
     When submitted, it will be passed to the corresponding constructor parameter.
   -->
-  <f:entry title="Username" field="username">
-    <f:textbox />
-  </f:entry>
-  <f:entry title="Password" field="password">
-    <f:password />
-  </f:entry>
+  <f:entry title="Credentials Id" field="credentialsId" name="credentialsId">
+	  	<f:select />
+	  </f:entry>
   <f:entry title="recordId" field="recordId">
     <f:textbox />
   </f:entry>
@@ -43,6 +40,6 @@
   
   <f:validateButton
    title="Verify Settings" progress="Verifying Settings ..."
-   method="testConnection" with="username,password,recordId,server" />
+   method="testConnection" with="credentialsId,recordId,server" />
    
 </j:jelly>

--- a/src/main/resources/com/pocketsoap/ChatterNotifier/help-credentialsId.html
+++ b/src/main/resources/com/pocketsoap/ChatterNotifier/help-credentialsId.html
@@ -1,0 +1,13 @@
+<div>
+	Utilizes the <a href="https://wiki.jenkins-ci.org/display/JENKINS/Credentials+Plugin">Credentials Plugin's</a> <em>Username with Password</em> credentials storage to
+	communicate with Chatter.
+	
+	<p>
+		If you're connecting from outside of your organizations trusted network, you'll also need
+		to append your API security token to your password. 
+	</p>
+	
+	<p>
+		See Identity Confirmation in the salesforce.com online help for more information.
+	</p>
+</div>

--- a/src/test/java/com/pocketsoap/ChatterNotifierTest.java
+++ b/src/test/java/com/pocketsoap/ChatterNotifierTest.java
@@ -1,0 +1,87 @@
+package com.pocketsoap;
+
+import hudson.util.ListBoxModel;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.tmatesoft.svn.core.SVNException;
+
+import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+
+/**
+ * Basic Chatter Notifier tests for Jenkins
+ * @author sortiz
+ */
+public class ChatterNotifierTest {
+	
+	@Rule
+	public JenkinsRule jenkins = new JenkinsRule();
+	
+	/**
+	 * Verify the getCredentialsById returns the right credentials by id
+	 * @throws IOException
+	 */
+	@Test public void testCredentialsExist() throws IOException {
+		//Insert some credentials
+		UsernamePasswordCredentialsImpl c = createFakeCredentials();
+		insertCredentials(c);
+		
+		//Verify the getCredentialsById returns the right credentials
+		UsernamePasswordCredentials foundCreds = ChatterNotifier.getCredentialsById(c.getId());
+		Assert.assertEquals(c.getUsername(), foundCreds.getUsername());
+		Assert.assertEquals(c.getPassword(), foundCreds.getPassword());
+	}
+	
+	@Test public void testCredentialsDoNotExist() throws IOException {
+		//Insert some credentials
+		UsernamePasswordCredentialsImpl c = createFakeCredentials();
+		insertCredentials(c);
+		
+		UsernamePasswordCredentials foundCreds = ChatterNotifier.getCredentialsById("idontexist");
+		Assert.assertNull(foundCreds);
+	}
+	
+	@Test public void testListBoxReturnsUsernamePassword() {
+		//Create a few dummy creds
+		UsernamePasswordCredentialsImpl userPass1 = createFakeCredentials();
+		//TODO: Add non-usernamepassword creds
+		
+		//Add to jenkins
+		insertCredentials(userPass1);
+		
+		ChatterNotifier.DescriptorImpl descriptor = new ChatterNotifier.DescriptorImpl();
+		ListBoxModel listBox = descriptor.doFillCredentialsIdItems();
+		Assert.assertTrue(listBox.size() > 0);	//Theres at least 1 empty item in there
+	}
+	
+	/**
+	 * Insert credentials into Jenkins
+	 * @param c A list of Credentials
+	 */
+	private void insertCredentials(Credentials... c) {
+		SystemCredentialsProvider.getInstance().setDomainCredentialsMap(Collections.singletonMap(Domain.global(), Arrays.<Credentials>asList(c)));
+	}
+	
+	/**
+	 * Create fake credentials
+	 * @return A Username Password Credential
+	 */
+	private UsernamePasswordCredentialsImpl createFakeCredentials() {
+		final String credentialsId = "test.credentials" + System.nanoTime();
+		final String username = "myuser@salesforce.com";
+		final String password = "s3cr3ts";
+		
+		return new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, credentialsId, "sample", username, password);
+	}
+}


### PR DESCRIPTION
I've made updates to use the Jenkins Credentials Plugin with the Chatter Plugin. 

Unfortunately, these changes are not backwards compatible. These changes remove the use of username and password fields (which are not secure) in favor of using UsernamePassword Credentials from Jenkins. 

I've also added a single test (ChatterNotifierTest) to to verify the credentials storage and retrieval works. 